### PR TITLE
Add crowd:params documentation comment

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,5 @@
+# Class crowd::params
+#
 class crowd::params {
 
   case $::osfamily {


### PR DESCRIPTION
This fixes a puppet-lint error:

remote: modules/crowd/manifests/params.pp - WARNING: class not documented on line 1
remote: Error: styleguide violation in modules/crowd/manifests/params.pp (see above)
remote: Error: 1 styleguide violation(s) found. Commit will be aborted.
remote: Please follow the puppet style guide outlined at:
remote: http://docs.puppetlabs.com/guides/style_guide.html

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>