### PR TITLE
Make compatible with umask 027

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,6 +66,8 @@ class crowd::install {
   staging::file { $file:
     source  => "${_download_url}/${file}",
     require => File[$crowd::app_dir],
+    owner   => $crowd::user,
+    group   => $crowd::group,
   }
 
   staging::extract { $file:


### PR DESCRIPTION
Our machines py policy run with a default umask of 027; when files and directories are created by Puppet without specifying a mode explicitly, this usually leads to files not being accessible.

Explicitly setting user and group here makes sure the file is readable by staging::extract even when umask is set to 027.