### PR TITLE
logdir variable made available to ensure logs are centrally located

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ Default:  ''
 
 Any custom JVM options to start Crowd with. Set in `setenv.sh` in `CATALINA_OPTS`.
 
+__`logdir`__
+
+Default:  '`/var/log/crowdir`'
+
+Set the folder to store log files in.
+
+
 __`db`__
 
 Default:  'mysql'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,7 @@ class crowd::config {
     owner   => $crowd::user,
     group   => $crowd::group,
   }
+  ->
   
   augeas { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
     lens    => 'Xml.lns',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,12 @@ class crowd::config {
     $_changes = $changes
   }
 
+  file { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
+    content => template('crowd/server.xml.erb'),
+    owner   => $crowd::user,
+    group   => $crowd::group,
+  }
+  
   augeas { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
     lens    => 'Xml.lns',
     incl    => "${crowd::app_dir}/apache-tomcat/conf/server.xml",
@@ -68,9 +74,5 @@ class crowd::config {
     group   => $crowd::group,
   }
 
-  file { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
-    content => template('crowd/server.xml.erb'),
-    owner   => $crowd::user,
-    group   => $crowd::group,
-  }
+
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,4 +50,27 @@ class crowd::config {
     group   => $crowd::group,
   }
 
+  file { "${crowd::app_dir}/apache-tomcat/conf/logging.properties":
+    content => template('crowd/logging.properties.erb'),
+    owner   => $crowd::user,
+    group   => $crowd::group,
+  }
+
+  file { "${crowd::app_dir}/crowd-webapp/WEB-INF/classes/log4j.properties":
+    content => template('crowd/log4j.properties.erb'),
+    owner   => $crowd::user,
+    group   => $crowd::group,
+  }
+
+  file { "${crowd::app_dir}/crowd-openidserver-webapp/WEB-INF/classes/log4j.properties":
+    content => template('crowd/openidserver-log4j.properties.erb'),
+    owner   => $crowd::user,
+    group   => $crowd::group,
+  }
+
+  file { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
+    content => template('crowd/server.xml.erb'),
+    owner   => $crowd::user,
+    group   => $crowd::group,
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,6 @@ class crowd::config {
     group   => $crowd::group,
   }
   ->
-  
   augeas { "${crowd::app_dir}/apache-tomcat/conf/server.xml":
     lens    => 'Xml.lns',
     incl    => "${crowd::app_dir}/apache-tomcat/conf/server.xml",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,8 +66,6 @@ class crowd::install {
   staging::file { $file:
     source  => "${_download_url}/${file}",
     require => File[$crowd::app_dir],
-    owner   => $crowd::user,
-    group   => $crowd::group,
   }
 
   staging::extract { $file:

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -1,0 +1,81 @@
+# LOGGING LEVELS
+# To turn more verbose logging on - "WARN", "DEBUG", "FATAL", "INFO"
+log4j.rootLogger=INFO, console, crowdlog
+
+#####################################################
+# LOG FILE LOCATIONS
+#####################################################
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d %t %p [%c{4}] %m%n
+
+
+log4j.appender.crowdlog=org.apache.log4j.RollingFileAppender
+log4j.appender.crowdlog.File=<%= scope.lookupvar('crowd::logdir') %>/atlassian-crowd.log
+
+#log4j.appender.crowdlog=com.atlassian.crowd.console.logging.CrowdHomeLogAppender
+log4j.appender.crowdlog.MaxFileSize=20480KB
+log4j.appender.crowdlog.MaxBackupIndex=5
+log4j.appender.crowdlog.layout=org.apache.log4j.PatternLayout
+log4j.appender.crowdlog.layout.ConversionPattern=%d %t %p [%c{4}] %m%n
+
+#####################################################
+# CROWD - CLASS-SPECIFIC LOGGING LEVELS
+#####################################################
+
+log4j.logger.atlassian.plugin=INFO
+
+log4j.logger.com.atlassian.license=ERROR
+
+log4j.logger.com.atlassian.plugin=INFO
+
+log4j.logger.com.atlassian.crowd=INFO
+log4j.logger.com.atlassian.crowd.license=ERROR
+
+# Set to DEBUG for HTTP request info
+log4j.logger.com.atlassian.crowd.plugin.web.filter.HttpRequestLoggingFilter=INFO
+
+# Set to DEBUG for authorization info
+log4j.logger.com.atlassian.crowd.manager.application.ApplicationServiceGeneric=INFO
+
+log4j.logger.com.atlassian.crowd.directory.SpringLDAPConnector=INFO
+
+# Set the following lines to DEBUG to enable logging on incoming, outgoing and fault SOAP messages
+log4j.logger.com.atlassian.crowd.service.soap.xfire.XFireInLoggingMethodHandler=WARN
+log4j.logger.com.atlassian.crowd.service.soap.xfire.XFireOutLoggingMethodHandler=WARN
+log4j.logger.com.atlassian.crowd.service.soap.xfire.XFireFaultLoggingMethodHandler=WARN
+
+# Bootstrap information on Crowd - Leave as 'INFO'.
+log4j.logger.com.atlassian.crowd.startup=INFO
+
+# set to DEBUG to output each individual batch entry to the log file
+# log4j.logger.com.atlassian.crowd.util.persistence.hibernate.batch.AbstractBatchProcessor=DEBUG
+
+#####################################################
+# LIBRARY - CLASS-SPECIFIC LOGGING LEVELS
+#####################################################
+
+log4j.logger.com.atlassian.util.profiling.UtilTimerStack=DEBUG
+
+log4j.logger.com.opensymphony=WARN
+
+log4j.logger.com.opensymphony.xwork2.util.OgnlUtil=ERROR
+
+log4j.logger.com.sun.jersey.core.spi.component.ProviderServices=WARN
+
+log4j.logger.org.apache.commons=WARN
+
+log4j.logger.org.codehaus=WARN
+
+log4j.logger.org.codehaus.xfire=WARN
+
+log4j.logger.org.hibernate=WARN
+log4j.logger.org.hibernate.orm.deprecation=ERROR
+
+log4j.logger.org.springframework=WARN
+
+log4j.logger.org.xbean=WARN
+
+log4j.logger.webwork=WARN

--- a/templates/logging.properties.erb
+++ b/templates/logging.properties.erb
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = <%= scope.lookupvar('crowd::logdir') %>
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+1catalina.org.apache.juli.AsyncFileHandler.maxDays = 5
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = <%= scope.lookupvar('crowd::logdir') %>
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+2localhost.org.apache.juli.AsyncFileHandler.maxDays = 5
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = <%= scope.lookupvar('crowd::logdir') %>
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+3manager.org.apache.juli.AsyncFileHandler.maxDays = 5
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = <%= scope.lookupvar('crowd::logdir') %>
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+4host-manager.org.apache.juli.AsyncFileHandler.maxDays = 5
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE
+
+# To see debug messages for HTTP/2 handling, uncomment the following line:
+#org.apache.coyote.http2.level = FINE
+
+# To see debug messages for WebSocket handling, uncomment the following line:
+#org.apache.tomcat.websocket.level = FINE

--- a/templates/openidserver-log4j.properties.erb
+++ b/templates/openidserver-log4j.properties.erb
@@ -1,0 +1,55 @@
+# LOGGING LEVELS
+# To turn more verbose logging on - "WARN", "DEBUG", "FATAL", "INFO"
+log4j.rootLogger=WARN, console, filelog
+
+#####################################################
+# LOG FILE LOCATIONS
+#####################################################
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d %t %p [%c{4}] %m%n
+
+log4j.appender.filelog=org.apache.log4j.RollingFileAppender
+log4j.appender.filelog.File=<%= scope.lookupvar('crowd::logdir') %>/atlassian-crowd-openid-server.log
+log4j.appender.filelog.MaxFileSize=20480KB
+log4j.appender.filelog.MaxBackupIndex=5
+log4j.appender.filelog.layout=org.apache.log4j.PatternLayout
+log4j.appender.filelog.layout.ConversionPattern=%d %t %p [%c{4}] %m%n
+
+#####################################################
+# CROWD - CLASS-SPECIFIC LOGGING LEVELS
+#####################################################
+
+log4j.logger.com.atlassian.crowd.openid.spray=INFO
+
+log4j.logger.com.atlassian.crowd.openid=INFO
+
+log4j.logger.com.atlassian.crowd=INFO
+
+#####################################################
+# LIBRARY - CLASS-SPECIFIC LOGGING LEVELS
+#####################################################
+
+log4j.logger.spray=WARN
+
+log4j.logger.akka=WARN
+
+log4j.logger.com.opensymphony=WARN
+
+log4j.logger.com.opensymphony.xwork2.util.OgnlUtil=ERROR
+
+log4j.logger.org.apache.commons=WARN
+
+log4j.logger.org.codehaus.=WARN
+
+log4j.logger.org.codehaus.xfire=WARN
+
+log4j.logger.org.hibernate=WARN
+
+log4j.logger.org.springframework=WARN
+
+log4j.logger.org.xbean=WARN
+
+log4j.logger.webwork=WARN

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -16,7 +16,7 @@
                    URIEncoding="UTF-8"
                    compression="on"
                    sendReasonPhrase="true"
-                   compressableMimeType="text/html,text/xml,application/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript" scheme="https" proxyName="kenhu-crowd.aws.capgemini-ips.com" proxyPort="443" />
+                   compressableMimeType="text/html,text/xml,application/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"/>
 
         <Engine defaultHost="localhost" name="Catalina">
             <Host appBase="webapps" autoDeploy="true" name="localhost" unpackWARs="true"/>

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Server port="8020" shutdown="SHUTDOWN">
+
+    <Service name="Catalina">
+
+        <Connector acceptCount="100"
+                   connectionTimeout="20000"
+                   disableUploadTimeout="true"
+                   enableLookups="false"
+                   maxHttpHeaderSize="8192"
+                   maxThreads="150"
+                   minSpareThreads="25"
+                   port="8095"
+                   redirectPort="8443"
+                   useBodyEncodingForURI="true"
+                   URIEncoding="UTF-8"
+                   compression="on"
+                   sendReasonPhrase="true"
+                   compressableMimeType="text/html,text/xml,application/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript" scheme="https" proxyName="kenhu-crowd.aws.capgemini-ips.com" proxyPort="443" />
+
+        <Engine defaultHost="localhost" name="Catalina">
+            <Host appBase="webapps" autoDeploy="true" name="localhost" unpackWARs="true"/>
+	          <Valve className="org.apache.catalina.valves.AccessLogValve" maxDays="5" directory="<%= scope.lookupvar('crowd::logdir') %>" prefix="localhost_access_log" suffix=".log" pattern="%t %{User-Agent}i %h %m %r %b %s %I %{X-AUSERNAME}o" />
+        </Engine>
+
+        <!-- To connect to an external web server (typically Apache) -->
+        <!-- Define an AJP 1.3 Connector on port 8009 -->
+        <!--
+            <Connector port="8009" enableLookups="false" redirectPort="8443" protocol="AJP/1.3" />
+        -->
+    </Service>
+
+    <!-- Security listener. Documentation at /docs/config/listeners.html
+    <Listener className="org.apache.catalina.security.SecurityListener" />
+    -->
+    <!--APR library loader. Documentation at /docs/apr.html -->
+    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+</Server>

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -3,9 +3,13 @@
 # Any changes made here will be lost.
 ##################################################
 JAVA_HOME="<%= scope.lookupvar('crowd::java_home') %>"
+
 CATALINA_OPTS="-Xms<%= scope.lookupvar('crowd::jvm_xms') %> -Xmx<%= scope.lookupvar('crowd::jvm_xmx') %> <%= scope.lookupvar('crowd::jvm_opts') %> -XX:MaxPermSize=<%= scope.lookupvar('crowd::jvm_permgen') %> -Dfile.encoding=UTF-8 $CATALINA_OPTS"
+
 CATALINA_PID="<%= scope.lookupvar('crowd::app_dir') %>/apache-tomcat/work/crowd.pid"
+CATALINA_OUT="<%= scope.lookupvar('crowd::logdir') %>/catalina.out"
 
 export JAVA_HOME
 export CATALINA_OPTS
 export CATALINA_PID
+export CATALINA_OUT


### PR DESCRIPTION
This code addition enables all crowd log files to placed under the same directory. The
logdir var is set and used, additional template files have been included for relevant logging handlers.  A 5 day retention period has also been set within templates, other than that the log handler templates are standard. Catalina.out also stored within $logdir.