### PR TITLE
Removing deprecated staging module dependency and adding proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ wizard, providing a license key and some basic configuration.
 Current dependencies are:
 
  * puppetlabs/stdlib
- * puppet/staging
+ * puppet/archive
 
 A Java installation is also required.
 [puppetlabs/java](https://forge.puppetlabs.com/puppetlabs/java) is recommended.
@@ -112,7 +112,20 @@ Default:  '/opt/crowd'
 
 The absolute base path to install Crowd to.  Within this path, Crowd will be
 installed to a sub-directory that matches the version.  Something like
-`atlassian-crowd-2.8.3-standalone`
+`atlassian-crowd-2.8.3-standalone`.  You can override this sub-directory by
+setting the 'appdir' parameter
+
+__`appdir`__
+
+Default: atlassian-${product}-${version}-standalone
+
+The sub-directory under installdir to install Crowd to.
+
+__`internet_proxy`__
+
+Default: undef
+
+Proxy setting to use if downloading Crowd behind a proxy.
 
 __`homedir`__
 
@@ -270,7 +283,7 @@ __`db`__
 
 Default:  'mysql'
 
-The database type to use.  The module supports either `mysql` or `postgres`
+The database type to use.  The module supports either `mysql`, `postgres`, or `oracle`.
 
 __`dbuser`__
 
@@ -308,8 +321,8 @@ __`dbdriver`__
 Default: undef
 
 Defaults to `com.mysql.jdbc.Driver` when `db` is set to `mysql` and
-`org.postgresql.Driver` when `db` is set to `postgres`
-
+`org.postgresql.Driver` when `db` is set to `postgres` and
+`oracle.jdbc.driver.OracleDriver` when `db is set to `oracle`.
 
 __`iddb`__
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class crowd (
 
   if !empty($jvm_opts) { validate_string($jvm_opts) }
 
-  validate_re($db, '^(mysql|postgres)$')
+  validate_re($db, '^(mysql|postgres|oracle)$')
   validate_re($dbuser, '^[a-z_][a-z0-9_-]*[$]?$')
   validate_string($dbpassword)
   validate_string($dbserver)
@@ -106,7 +106,7 @@ class crowd (
   if $dbport { validate_integer($dbport) }
   if $dbdriver { validate_string($dbdriver) }
 
-  validate_re($iddb, '^(mysql|postgres)$')
+  validate_re($iddb, '^(mysql|postgres|oracle)$')
   validate_re($iddbuser, '^[a-z_][a-z0-9_-]*[$]?$')
   validate_string($iddbpassword)
   validate_string($iddbserver)
@@ -152,6 +152,17 @@ class crowd (
       }
       $dbtype = 'postgresql'
     }
+    'oracle': {
+      $_dbport = $dbport ? {
+        undef   => '1521',
+        default => $dbport,
+      }
+      $_dbdriver = $dbdriver ? {
+        undef   => 'oracle.jdbc.driver.OracleDriver',
+        default => $dbdriver,
+      }
+      $dbtype = 'oracle'
+    }
     default: {
       warning("db database type ${db} is not supported")
     }
@@ -179,6 +190,17 @@ class crowd (
         default => $iddbdriver,
       }
       $iddbtype = 'postgresql'
+    }
+    'oracle': {
+      $_iddbport = $iddbport ? {
+        undef   => '1521',
+        default => $iddbport,
+      }
+      $_iddbdriver = $iddbdriver ? {
+        undef   => 'oracle.jdbc.driver.OracleDriver',
+        default => $iddbdriver,
+      }
+      $iddbtype = 'oracle'
     }
     default: {
       warning("iddb database type ${iddb} is not supported")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class crowd (
   $facter_dir                 = $crowd::params::facter_dir,
   $create_facter_dir          = true,
   $stop_command               = $crowd::params::stop_command,
+  $internet_proxy             = undef,
 ) inherits crowd::params {
 
   validate_re($version, '^\d+\.\d+.\d+$')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,3 @@
-
 # == Class: crowd
 #
 # Refer to the README for documentation
@@ -8,6 +7,7 @@ class crowd (
   $extension                  = 'tar.gz',
   $product                    = 'crowd',
   $installdir                 = '/opt/crowd',
+  $appdir                     = "atlassian-${product}-${version}-standalone",
   $homedir                    = '/var/local/crowd',
   $logdir                     = '/var/log/crowd',
   $tomcat_port                = '8095',
@@ -207,7 +207,7 @@ class crowd (
     }
   }
 
-  $app_dir = "${installdir}/atlassian-${product}-${version}-standalone"
+  $app_dir = "${installdir}/${appdir}"
   $dburl   = "jdbc:${dbtype}://${dbserver}:${_dbport}/${dbname}"
   $iddburl = "jdbc:${iddbtype}://${iddbserver}:${_iddbport}/${iddbname}"
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,17 +64,18 @@ class crowd::install {
   }
 
   archive { $file:
-    source         => "${_download_url}/${file}",
-    path           => "/tmp/$file",
-    extract        => true,
-    extract_path   => $crowd::app_dir,
-    cleanup        => true,
-    proxy_server   => $crowd::internet_proxy,
-    allow_insecure => true,
-    creates        => "${crowd::app_dir}/apache-tomcat",
-    user           => $crowd::user,
-    group          => $crowd::group,
-    require        => File[$crowd::app_dir],
+    source          => "${_download_url}/${file}",
+    path            => "/tmp/$file",
+    extract         => true,
+    extract_command => 'tar xzf %s --strip-components=1',
+    extract_path    => $crowd::app_dir,
+    cleanup         => true,
+    proxy_server    => $crowd::internet_proxy,
+    allow_insecure  => true,
+    creates         => "${crowd::app_dir}/apache-tomcat",
+    user            => $crowd::user,
+    group           => $crowd::group,
+    require         => File[$crowd::app_dir],
   }
 
   file { $crowd::logdir:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -67,7 +67,7 @@ class crowd::install {
     source         => "${_download_url}/${file}",
     path           => "/tmp/$file",
     extract        => true,
-    extract_path   => $crowd::installdir,
+    extract_path   => $crowd::app_dir,
     cleanup        => true,
     proxy_server   => $crowd::internet_proxy,
     allow_insecure => true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -95,7 +95,7 @@ class crowd::install {
         source       => $crowd::mysql_driver,
         path         => "${crowd::app_dir}/apache-tomcat/lib/${driver_file}",
         extract      => false,
-        cleanup      => false
+        cleanup      => false,
         proxy_server => $crowd::internet_proxy,
         before       => Exec["chown_${crowd::app_dir}"],
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -106,7 +106,6 @@ class crowd::install {
     command   => "chown -R ${crowd::user}:${crowd::group} ${crowd::app_dir}",
     unless    => "find ${crowd::app_dir} ! -type l \\( ! -user ${crowd::user} -type f \\) -o \\( ! -group ${crowd::group} \\) -a \\( -type f \\)| wc -l | awk '{print \$1}' | grep -qE '^0'",
     path      => '/bin:/usr/bin',
-    subscribe => User[$crowd::user],
     require   => Archive[$file],
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,26 +57,24 @@ class crowd::install {
       exec { 'stop crowd for update':
         command => $stop_command,
         path    => $::path,
-        require => Staging::File[$file],
-        before  => Staging::Extract[$file],
+        require => Archive[$file],
+        before  => Archive[$file],
       }
     }
   }
 
-  staging::file { $file:
-    source  => "${_download_url}/${file}",
-    require => File[$crowd::app_dir],
-    owner   => $crowd::user,
-    group   => $crowd::group,
-  }
-
-  staging::extract { $file:
-    target  => $crowd::app_dir,
-    creates => "${crowd::app_dir}/apache-tomcat",
-    strip   => 1,
-    user    => $crowd::user,
-    group   => $crowd::group,
-    require => Staging::File[$file],
+  archive { $file:
+    source         => "${_download_url}/${file}",
+    path           => "/tmp/$file",
+    extract        => true,
+    extract_path   => $crowd::installdir,
+    cleanup        => true,
+    proxy_server   => $crowd::internet_proxy,
+    allow_insecure => true,
+    creates        => "${crowd::app_dir}/apache-tomcat",
+    user           => $crowd::user,
+    group          => $crowd::group,
+    require        => File[$crowd::app_dir],
   }
 
   file { $crowd::logdir:
@@ -93,10 +91,13 @@ class crowd::install {
 
   if $crowd::db == 'mysql' {
     if $crowd::download_driver {
-      staging::file { 'jdbc driver':
-        source => $crowd::mysql_driver,
-        target => "${crowd::app_dir}/apache-tomcat/lib/${driver_file}",
-        before => Exec["chown_${crowd::app_dir}"],
+      archive { 'jdbc driver':
+        source       => $crowd::mysql_driver,
+        path         => "${crowd::app_dir}/apache-tomcat/lib/${driver_file}",
+        extract      => false,
+        cleanup      => false
+        proxy_server => $crowd::internet_proxy,
+        before       => Exec["chown_${crowd::app_dir}"],
       }
     }
   }
@@ -106,7 +107,7 @@ class crowd::install {
     unless    => "find ${crowd::app_dir} ! -type l \\( ! -user ${crowd::user} -type f \\) -o \\( ! -group ${crowd::group} \\) -a \\( -type f \\)| wc -l | awk '{print \$1}' | grep -qE '^0'",
     path      => '/bin:/usr/bin',
     subscribe => User[$crowd::user],
-    require   => Staging::Extract[$file],
+    require   => Archive[$file],
   }
 
 }


### PR DESCRIPTION
This is a change to remove this module's dependency on the deprecated 'staging' module by migrating to 'archive'.  This change also allows us to pass a proxy server parameter in the crowd class declaration so we can download Crowd when behind a proxy.  I've also added 'oracle' as a possible database type, and made the value of app_dir configurable by adding an 'appdir' class parameter.